### PR TITLE
Added threads message layout

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, dev ]
 
 jobs:
-  version-bump-build-and-release:
+  build-and-release:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
     steps:
@@ -17,10 +17,12 @@ jobs:
       
       - name: Get latest tag
         id: get_latest_tag
+        if: github.ref == 'refs/heads/main'
         run: echo "latest_tag=$(git describe --tags --abbrev=0 || echo v0.0.0)" >> $GITHUB_OUTPUT
       
       - name: Bump version
         id: bump_version
+        if: github.ref == 'refs/heads/main'
         run: |
           latest_tag=${{ steps.get_latest_tag.outputs.latest_tag }}
           major=$(echo $latest_tag | cut -d. -f1 | tr -d v)
@@ -31,10 +33,12 @@ jobs:
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
       
       - name: Update pubspec.yaml
+        if: github.ref == 'refs/heads/main'
         run: |
           sed -i 's/^version: .*/version: ${{ steps.bump_version.outputs.new_version }}+${{ github.run_number }}/g' pubspec.yaml
       
       - name: Commit changes
+        if: github.ref == 'refs/heads/main'
         run: |
           git config --local user.email "sannidhyadubey@gmail.com"
           git config --local user.name "TheGuyDangerous"
@@ -42,6 +46,7 @@ jobs:
           git commit -m "Bump version to ${{ steps.bump_version.outputs.new_version }}+${{ github.run_number }}"
       
       - name: Push changes
+        if: github.ref == 'refs/heads/main'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -97,7 +97,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: apks
-          path: build/app/outputs/flutter-apk/*.apk
+          path: |
+            build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
+            build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+            build/app/outputs/flutter-apk/app-x86_64-release.apk
+          retention-days: 5
 
       - name: Create Release
         if: github.ref == 'refs/heads/main'
@@ -142,15 +146,7 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/app/outputs/flutter-apk/app-x86_64-release.apk
           asset_name: freelexity-v${{ steps.bump_version.outputs.new_version }}-x86_64.apk
-          asset_content_type: application/vnd.android.package-archive
-
-      - name: Upload Dev APKs as artifacts
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dev-apks
-          path: build/app/outputs/flutter-apk/*.apk
-          retention-days: 5
+          asset_content_type: application/vnd.android.package-archive 
 
       - name: Final Debug
         if: always()

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       
@@ -48,7 +48,7 @@ jobs:
           branch: ${{ github.ref }}
 
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -72,19 +72,24 @@ jobs:
       - name: Cache Pub dependencies
         uses: actions/cache@v3
         with:
-          path: ${{ env.FLUTTER_HOME }}/.pub-cache
+          path: ${{ env.PUB_CACHE }}
           key: ${{ runner.os }}-pub-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-pub-
       
       - name: Get dependencies
         run: flutter pub get
+
+      - name: Debug Pub Cache
+        run: |
+          echo "PUB_CACHE: $PUB_CACHE"
+          ls -R $PUB_CACHE || echo "PUB_CACHE directory not found"
       
       - name: Build APK
         run: flutter build apk --release --split-per-abi
 
       - name: Upload APKs as artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: apks
           path: build/app/outputs/flutter-apk/*.apk
@@ -133,3 +138,19 @@ jobs:
           asset_path: ./build/app/outputs/flutter-apk/app-x86_64-release.apk
           asset_name: freelexity-v${{ steps.bump_version.outputs.new_version }}-x86_64.apk
           asset_content_type: application/vnd.android.package-archive
+
+      - name: Upload Dev APKs as artifacts
+        if: github.ref == 'refs/heads/dev'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-apks
+          path: build/app/outputs/flutter-apk/*.apk
+          retention-days: 5
+
+      - name: Final Debug
+        if: always()
+        run: |
+          echo "Gradle cache:"
+          ls -R ~/.gradle/caches || echo "Gradle cache not found"
+          echo "Pub cache:"
+          ls -R $PUB_CACHE || echo "Pub cache not found"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 *.pyc
 *.swp
+.cursorignore
 .DS_Store
 .atom/
 .buildlog/

--- a/lib/widgets/thread/follow_up_input.dart
+++ b/lib/widgets/thread/follow_up_input.dart
@@ -3,7 +3,7 @@ import 'package:iconsax/iconsax.dart';
 
 class FollowUpInput extends StatelessWidget {
   final TextEditingController controller;
-  final VoidCallback onSubmitted;
+  final Function(String) onSubmitted;
 
   const FollowUpInput({
     super.key,
@@ -40,7 +40,7 @@ class FollowUpInput extends StatelessWidget {
                 ),
                 border: InputBorder.none,
               ),
-              onSubmitted: (_) => onSubmitted(),
+              onSubmitted: (_) => onSubmitted(controller.text),
             ),
           ),
           IconButton(
@@ -50,7 +50,7 @@ class FollowUpInput extends StatelessWidget {
                   ? Colors.white
                   : Colors.black,
             ),
-            onPressed: onSubmitted,
+            onPressed: () => onSubmitted(controller.text),
           ),
         ],
       ),

--- a/lib/widgets/thread/related_questions.dart
+++ b/lib/widgets/thread/related_questions.dart
@@ -2,12 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:iconsax/iconsax.dart';
 import 'package:provider/provider.dart';
 import '../../theme_provider.dart';
-import '../../screens/thread/thread_loading_screen.dart';
 
 class RelatedQuestions extends StatelessWidget {
   final List<String> questions;
+  final Function(String) onQuestionSelected;
 
-  const RelatedQuestions({super.key, required this.questions});
+  const RelatedQuestions({
+    super.key,
+    required this.questions,
+    required this.onQuestionSelected,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -59,14 +63,7 @@ class RelatedQuestions extends StatelessWidget {
               ),
               contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
               dense: true,
-              onTap: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder: (context) =>
-                        ThreadLoadingScreen(query: questions[index]),
-                  ),
-                );
-              },
+              onTap: () => onQuestionSelected(questions[index]),
             );
           },
         ),

--- a/lib/widgets/thread/sources_section.dart
+++ b/lib/widgets/thread/sources_section.dart
@@ -2,98 +2,221 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../theme_provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:iconsax/iconsax.dart';
 
-class SourcesSection extends StatelessWidget {
+class SourcesSection extends StatefulWidget {
   final List<Map<String, dynamic>> searchResults;
 
   const SourcesSection({super.key, required this.searchResults});
 
   @override
+  _SourcesSectionState createState() => _SourcesSectionState();
+}
+
+class _SourcesSectionState extends State<SourcesSection> {
+  bool _isExpanded = false;
+
+  @override
   Widget build(BuildContext context) {
     final themeProvider = Provider.of<ThemeProvider>(context);
 
-    return Container(
-      height: 80,
-      margin: EdgeInsets.symmetric(vertical: 16),
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        itemCount: searchResults.length,
-        itemBuilder: (context, index) {
-          final result = searchResults[index];
-          return GestureDetector(
-            onTap: () => _showSourceDetails(context, result, themeProvider),
-            child: Container(
-              width: 200,
-              margin: EdgeInsets.only(right: 8, left: index == 0 ? 16 : 0),
-              padding: EdgeInsets.all(8),
-              decoration: BoxDecoration(
-                color: themeProvider.isDarkMode
-                    ? Colors.grey[800]
-                    : Colors.grey[300],
-                borderRadius: BorderRadius.circular(12),
-              ),
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          _isExpanded = !_isExpanded;
+        });
+      },
+      child: AnimatedContainer(
+        duration: Duration(milliseconds: 300),
+        height: _isExpanded ? null : 80,
+        margin: EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+        decoration: BoxDecoration(
+          color: themeProvider.isDarkMode
+              ? Colors.grey[800]!.withOpacity(0.5)
+              : Colors.grey[300]!.withOpacity(0.5),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          children: [
+            Container(
+              height: 80,
+              padding: EdgeInsets.symmetric(horizontal: 16),
               child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Container(
-                    width: 24,
-                    height: 24,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: themeProvider.isDarkMode
-                          ? Colors.white
-                          : Colors.black,
-                    ),
-                    child: Center(
-                      child: Text(
-                        '${index + 1}',
+                  Row(
+                    children: [
+                      Icon(
+                        Iconsax.document,
+                        color: themeProvider.isDarkMode
+                            ? Colors.white
+                            : Colors.black,
+                      ),
+                      SizedBox(width: 8),
+                      Text(
+                        'Sources',
                         style: TextStyle(
                           color: themeProvider.isDarkMode
-                              ? Colors.black
-                              : Colors.white,
+                              ? Colors.white
+                              : Colors.black,
                           fontWeight: FontWeight.bold,
-                          fontSize: 12,
+                          fontSize: 16,
                         ),
                       ),
-                    ),
+                    ],
                   ),
-                  SizedBox(width: 8),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          result['title'] ?? '',
-                          style: TextStyle(
-                            color: themeProvider.isDarkMode
-                                ? Colors.white
-                                : Colors.black,
-                            fontSize: 14,
-                            fontWeight: FontWeight.bold,
-                          ),
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        SizedBox(height: 4),
-                        Text(
-                          Uri.parse(result['url'] ?? '').host,
-                          style: TextStyle(
-                              color: themeProvider.isDarkMode
-                                  ? Colors.white70
-                                  : Colors.black54,
-                              fontSize: 12),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
-                    ),
+                  Row(
+                    children: [
+                      _buildFaviconStack(),
+                      SizedBox(width: 8),
+                      Icon(
+                        _isExpanded
+                            ? Icons.arrow_drop_up
+                            : Icons.arrow_drop_down,
+                        color: themeProvider.isDarkMode
+                            ? Colors.white
+                            : Colors.black,
+                      ),
+                    ],
                   ),
                 ],
               ),
             ),
-          );
-        },
+            if (_isExpanded)
+              Container(
+                height: 80,
+                child: ScrollConfiguration(
+                  behavior: BouncyScrollBehavior(),
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: widget.searchResults.length,
+                    itemBuilder: (context, index) {
+                      final result = widget.searchResults[index];
+                      final isLastItem =
+                          index == widget.searchResults.length - 1;
+                      return GestureDetector(
+                        onTap: () =>
+                            _showSourceDetails(context, result, themeProvider),
+                        child: Container(
+                          width: 200,
+                          margin: EdgeInsets.only(
+                            left: index == 0 ? 16 : 8,
+                            right: isLastItem ? 10 : 2,
+                            bottom: 16,
+                          ),
+                          padding: EdgeInsets.all(8),
+                          decoration: BoxDecoration(
+                            color: themeProvider.isDarkMode
+                                ? Colors.grey[700]
+                                : Colors.grey[200],
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Row(
+                            children: [
+                              _buildFavicon(result['url']),
+                              SizedBox(width: 8),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Text(
+                                      result['title'] ?? '',
+                                      style: TextStyle(
+                                        color: themeProvider.isDarkMode
+                                            ? Colors.white
+                                            : Colors.black,
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                    SizedBox(height: 4),
+                                    Text(
+                                      Uri.parse(result['url'] ?? '').host,
+                                      style: TextStyle(
+                                        color: themeProvider.isDarkMode
+                                            ? Colors.white70
+                                            : Colors.black54,
+                                        fontSize: 12,
+                                      ),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+          ],
+        ),
       ),
+    );
+  }
+
+  Widget _buildFavicon(String? url) {
+    return Container(
+      width: 24,
+      height: 24,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: Colors.white,
+        border: Border.all(color: Colors.grey[300]!, width: 1),
+      ),
+      child: ClipOval(
+        child: Image.network(
+          'https://www.google.com/s2/favicons?domain=${Uri.parse(url ?? '').host}&sz=64',
+          width: 16,
+          height: 16,
+          fit: BoxFit.cover,
+          errorBuilder: (context, error, stackTrace) {
+            return Icon(Icons.public, size: 16);
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFaviconStack() {
+    List<Widget> favicons = [];
+    for (int i = 0; i < widget.searchResults.length && i < 2; i++) {
+      favicons.add(
+        Positioned(
+          left: i * 15.0,
+          child: Container(
+            width: 24,
+            height: 24,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: Colors.white,
+              border: Border.all(color: Colors.grey[300]!, width: 1),
+            ),
+            child: ClipOval(
+              child: Image.network(
+                'https://www.google.com/s2/favicons?domain=${Uri.parse(widget.searchResults[i]['url'] ?? '').host}&sz=64',
+                width: 16,
+                height: 16,
+                fit: BoxFit.cover,
+                errorBuilder: (context, error, stackTrace) {
+                  return Icon(Icons.public, size: 16);
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+    return Container(
+      width: 40,
+      height: 24,
+      child: Stack(children: favicons),
     );
   }
 
@@ -226,5 +349,12 @@ class SourcesSection extends StatelessWidget {
     } else {
       debugPrint('Could not launch $url');
     }
+  }
+}
+
+class BouncyScrollBehavior extends ScrollBehavior {
+  @override
+  ScrollPhysics getScrollPhysics(BuildContext context) {
+    return BouncingScrollPhysics();
   }
 }

--- a/lib/widgets/thread/summary_card.dart
+++ b/lib/widgets/thread/summary_card.dart
@@ -31,14 +31,27 @@ class SummaryCard extends StatelessWidget {
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
-                  'Answer',
-                  style: TextStyle(
-                    color:
-                        themeProvider.isDarkMode ? Colors.white : Colors.black,
-                    fontSize: 18,
-                    fontWeight: FontWeight.bold,
-                  ),
+                Row(
+                  children: [
+                    Icon(
+                      Iconsax.magic_star,
+                      color: themeProvider.isDarkMode
+                          ? Colors.white
+                          : Colors.black,
+                      size: 24,
+                    ),
+                    SizedBox(width: 8),
+                    Text(
+                      'Answer',
+                      style: TextStyle(
+                        color: themeProvider.isDarkMode
+                            ? Colors.white
+                            : Colors.black,
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
                 ),
                 IconButton(
                   icon: Icon(
@@ -55,8 +68,9 @@ class SummaryCard extends StatelessWidget {
             Text(
               summary,
               style: TextStyle(
-                  color: themeProvider.isDarkMode ? Colors.white : Colors.black,
-                  fontSize: 16),
+                color: themeProvider.isDarkMode ? Colors.white : Colors.black,
+                fontSize: 16,
+              ),
             ),
           ],
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "An open-source answer engine built with Flutter."
 
 publish_to: 'none'
 
-version: 0.28.1+30
+version: 0.28.1+33
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
This pull request includes significant updates to the build and release workflow and substantial changes to the `ThreadScreenState` class to improve the handling of thread sections.

### Workflow Improvements:
* [`.github/workflows/build_and_release.yml`](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L10-R10): Renamed the job from `version-bump-build-and-release` to `build-and-release` and added conditions to several steps to only run on the `main` branch. Additionally, updated the cache path and added debugging steps. [[1]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L10-R10) [[2]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437R20-R25) [[3]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437R36-R49) [[4]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L75-R104) [[5]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437R150-R157)

### Thread Screen Enhancements:
* [`lib/screens/thread/thread_screen_state.dart`](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L24-R29): Refactored the `ThreadScreenState` class to use a list of `ThreadSection` objects, allowing for better management of related questions, images, and search results. Introduced methods for adding initial and follow-up sections and performing searches. [[1]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L24-R29) [[2]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8R38) [[3]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L85-R86) [[4]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L114-R115) [[5]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L128-R129) [[6]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L140-R141) [[7]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L150-R151) [[8]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L162-R166) [[9]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L180-R186) [[10]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L204-L219) [[11]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8R216-R253) [[12]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L279-L320) [[13]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8R360-R431)

### Widget Updates:
* [`lib/widgets/thread/follow_up_input.dart`](diffhunk://#diff-7005408e748d497c60eb39e470accdc7e45c6831432ed10fd4009e4b330c894aL6-R6): Modified the `FollowUpInput` widget to accept a callback that receives the input text, improving the handling of follow-up queries. [[1]](diffhunk://#diff-7005408e748d497c60eb39e470accdc7e45c6831432ed10fd4009e4b330c894aL6-R6) [[2]](diffhunk://#diff-7005408e748d497c60eb39e470accdc7e45c6831432ed10fd4009e4b330c894aL43-R43) [[3]](diffhunk://#diff-7005408e748d497c60eb39e470accdc7e45c6831432ed10fd4009e4b330c894aL53-R53)
* [`lib/widgets/thread/related_questions.dart`](diffhunk://#diff-ea4db475f88ebba7f61f902fdb220fb0fdabe148c1030e6e2720d0f21c795652L5-R14): Updated the `RelatedQuestions` widget to use a callback for handling question selection, removing the navigation logic. [[1]](diffhunk://#diff-ea4db475f88ebba7f61f902fdb220fb0fdabe148c1030e6e2720d0f21c795652L5-R14) [[2]](diffhunk://#diff-ea4db475f88ebba7f61f902fdb220fb0fdabe148c1030e6e2720d0f21c795652L62-R66)

These changes collectively enhance the functionality and maintainability of the thread screen, streamline the build and release process, and improve the user experience.