### PR TITLE
Added Download a Thread feature

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -94,7 +94,7 @@ jobs:
         run: flutter build apk --release --split-per-abi
 
       - name: Upload armeabi-v7a APK
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/dev'
         uses: actions/upload-artifact@v4
         with:
           name: app-armeabi-v7a-release
@@ -102,7 +102,7 @@ jobs:
           retention-days: 5
 
       - name: Upload arm64-v8a APK
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/dev'
         uses: actions/upload-artifact@v4
         with:
           name: app-arm64-v8a-release
@@ -110,7 +110,7 @@ jobs:
           retention-days: 5
 
       - name: Upload x86_64 APK
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/dev'
         uses: actions/upload-artifact@v4
         with:
           name: app-x86_64-release
@@ -137,7 +137,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
-          asset_name: freelexity-v${{ steps.bump_version.outputs.new_version }}-armeabi-v7a.apk
+          asset_name: Freelexity-v${{ steps.bump_version.outputs.new_version }}-armeabi-v7a.apk
           asset_content_type: application/vnd.android.package-archive
 
       - name: Upload arm64-v8a APK
@@ -159,7 +159,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./build/app/outputs/flutter-apk/app-x86_64-release.apk
-          asset_name: freelexity-v${{ steps.bump_version.outputs.new_version }}-x86_64.apk
+          asset_name: Freelexity-v${{ steps.bump_version.outputs.new_version }}-x86_64.apk
           asset_content_type: application/vnd.android.package-archive 
 
       - name: Final Debug
@@ -169,27 +169,3 @@ jobs:
           ls -R ~/.gradle/caches || echo "Gradle cache not found"
           echo "Pub cache:"
           ls -R $PUB_CACHE || echo "Pub cache not found"
-
-      - name: Upload Dev APKs as artifacts
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dev-apk-armeabi-v7a
-          path: build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk
-          retention-days: 5
-
-      - name: Upload Dev APKs as artifacts
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dev-apk-arm64-v8a
-          path: build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
-          retention-days: 5
-
-      - name: Upload Dev APKs as artifacts
-        if: github.ref == 'refs/heads/dev'
-        uses: actions/upload-artifact@v4
-        with:
-          name: dev-apk-x86_64
-          path: build/app/outputs/flutter-apk/app-x86_64-release.apk
-          retention-days: 5

--- a/lib/screens/library/library_screen_state.dart
+++ b/lib/screens/library/library_screen_state.dart
@@ -5,7 +5,6 @@ import 'dart:io';
 import '../../widgets/library/history_list.dart';
 import '../../widgets/library/empty_state.dart';
 import '../../widgets/library/incognito_message.dart';
-import '../../services/search_service.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
 import 'package:provider/provider.dart';
 import '../../theme_provider.dart';
@@ -17,7 +16,6 @@ const int maxHistoryItems = 50;
 
 class LibraryScreenState extends State<LibraryScreen> {
   List<Map<String, dynamic>> _searchHistory = [];
-  final SearchService _searchService = SearchService();
   bool _isIncognitoMode = false;
   final RefreshController _refreshController =
       RefreshController(initialRefresh: false);

--- a/lib/screens/thread/thread_loading_screen.dart
+++ b/lib/screens/thread/thread_loading_screen.dart
@@ -1,14 +1,24 @@
 import 'package:flutter/material.dart';
+import 'dart:convert';
+import 'dart:io';
 import '../../widgets/thread/loading_shimmer.dart';
 import '../../services/search_service.dart';
 import 'thread_screen.dart';
 import '../../theme_provider.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ThreadLoadingScreen extends StatefulWidget {
   final String query;
+  final String? savedThreadPath;
+  final Map<String, dynamic>? savedThreadData;
 
-  const ThreadLoadingScreen({super.key, required this.query});
+  const ThreadLoadingScreen({
+    Key? key,
+    required this.query,
+    this.savedThreadPath,
+    this.savedThreadData,
+  }) : super(key: key);
 
   @override
   State<ThreadLoadingScreen> createState() => _ThreadLoadingScreenState();
@@ -21,33 +31,62 @@ class _ThreadLoadingScreenState extends State<ThreadLoadingScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _performSearch();
+      _loadThreadOrSearch();
     });
+  }
+
+  Future<void> _loadThreadOrSearch() async {
+    if (widget.savedThreadData != null) {
+      _navigateToThreadScreen(widget.savedThreadData!);
+    } else if (widget.savedThreadPath != null) {
+      await _loadSavedThread(widget.savedThreadPath!);
+    } else {
+      await _performSearch();
+    }
+  }
+
+  Future<void> _loadSavedThread(String path) async {
+    try {
+      final file = File(path);
+      if (await file.exists()) {
+        final jsonString = await file.readAsString();
+        final threadData = json.decode(jsonString);
+        _navigateToThreadScreen(threadData);
+      } else {
+        await _performSearch();
+      }
+    } catch (e) {
+      debugPrint('Error loading saved thread: $e');
+      await _performSearch();
+    }
   }
 
   Future<void> _performSearch() async {
     final results = await _searchService.performSearch(context, widget.query);
     if (mounted) {
       if (results != null) {
-        Navigator.of(context).pushReplacement(
-          PageRouteBuilder(
-            pageBuilder: (context, animation, secondaryAnimation) =>
-                ThreadScreen(
-              query: results['query'],
-              searchResults: results['searchResults'],
-              summary: results['summary'],
-            ),
-            transitionsBuilder:
-                (context, animation, secondaryAnimation, child) {
-              return FadeTransition(opacity: animation, child: child);
-            },
-            transitionDuration: Duration(milliseconds: 300),
-          ),
-        );
+        _navigateToThreadScreen(results);
       } else {
         Navigator.of(context).pop();
       }
     }
+  }
+
+  void _navigateToThreadScreen(Map<String, dynamic> data) {
+    Navigator.of(context).pushReplacement(
+      PageRouteBuilder(
+        pageBuilder: (context, animation, secondaryAnimation) => ThreadScreen(
+          query: data['query'],
+          searchResults: List<Map<String, dynamic>>.from(data['searchResults']),
+          summary: data['summary'],
+          savedSections: data['sections'] as List<dynamic>?,
+        ),
+        transitionsBuilder: (context, animation, secondaryAnimation, child) {
+          return FadeTransition(opacity: animation, child: child);
+        },
+        transitionDuration: Duration(milliseconds: 300),
+      ),
+    );
   }
 
   @override
@@ -57,7 +96,10 @@ class _ThreadLoadingScreenState extends State<ThreadLoadingScreen> {
     return Scaffold(
       backgroundColor: themeProvider.isDarkMode ? Colors.black : Colors.white,
       appBar: AppBar(
-        title: Text('Searching...'),
+        title: Text(
+            widget.savedThreadPath != null || widget.savedThreadData != null
+                ? 'Loading Saved Thread'
+                : 'Searching...'),
         backgroundColor: themeProvider.isDarkMode ? Colors.black : Colors.white,
         foregroundColor: themeProvider.isDarkMode ? Colors.white : Colors.black,
       ),

--- a/lib/screens/thread/thread_screen.dart
+++ b/lib/screens/thread/thread_screen.dart
@@ -5,13 +5,15 @@ class ThreadScreen extends StatefulWidget {
   final String query;
   final List<Map<String, dynamic>> searchResults;
   final String summary;
+  final List<dynamic>? savedSections;
 
   const ThreadScreen({
-    super.key,
+    Key? key,
     required this.query,
     required this.searchResults,
     required this.summary,
-  });
+    this.savedSections,
+  }) : super(key: key);
 
   @override
   ThreadScreenState createState() => ThreadScreenState();

--- a/lib/screens/thread/thread_screen.dart
+++ b/lib/screens/thread/thread_screen.dart
@@ -8,12 +8,12 @@ class ThreadScreen extends StatefulWidget {
   final List<dynamic>? savedSections;
 
   const ThreadScreen({
-    Key? key,
+    super.key,
     required this.query,
     required this.searchResults,
     required this.summary,
     this.savedSections,
-  }) : super(key: key);
+  });
 
   @override
   ThreadScreenState createState() => ThreadScreenState();

--- a/lib/screens/thread/thread_screen_state.dart
+++ b/lib/screens/thread/thread_screen_state.dart
@@ -15,13 +15,15 @@ import 'thread_screen.dart';
 import 'package:provider/provider.dart';
 import '../../theme_provider.dart';
 import '../../utils/constants.dart';
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
 
 class ThreadScreenState extends State<ThreadScreen>
     with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
   late Animation<double> _animation;
   final TextEditingController _followUpController = TextEditingController();
-  final List<ThreadSection> _threadSections = [];
+  List<ThreadSection> _threadSections = []; // Changed from final to non-final
   bool _isIncognitoMode = false;
   bool _isSpeaking = false;
   late FlutterTts _flutterTts;
@@ -33,9 +35,13 @@ class ThreadScreenState extends State<ThreadScreen>
     super.initState();
     _initializeAnimation();
     _loadIncognitoMode();
-    _loadData();
     _initializeTts();
-    _addInitialSection();
+    if (widget.savedSections != null) {
+      _loadSavedSections();
+    } else {
+      _addInitialSection();
+      _loadData();
+    }
   }
 
   void _initializeAnimation() {
@@ -201,16 +207,77 @@ class ThreadScreenState extends State<ThreadScreen>
     }
   }
 
-  void _shareSearchResult() {
-    final String shareText =
-        'Query: ${widget.query}\n\nAnswer: ${widget.summary}\n\nSearch with ${AppConstants.appName}: ${AppConstants.githubUrl}';
-    Clipboard.setData(ClipboardData(text: shareText)).then((_) {
+  Future<void> _downloadThread() async {
+    try {
+      final threadData = {
+        'query': widget.query,
+        'summary': widget.summary,
+        'searchResults': widget.searchResults,
+        'sections': _threadSections
+            .map((section) => {
+                  'query': section.query,
+                  'summary': section.summary,
+                  'searchResults': section.searchResults,
+                  'relatedQuestions': section.relatedQuestions,
+                  'images': section.images,
+                })
+            .toList(),
+      };
+
+      final directory = await getApplicationDocumentsDirectory();
+      final fileName = 'thread_${DateTime.now().millisecondsSinceEpoch}.json';
+      final file = File('${directory.path}/$fileName');
+
+      await file.writeAsString(json.encode(threadData));
+      debugPrint('Thread saved to file: ${file.path}');
+
+      // Save the file path to SharedPreferences
+      final prefs = await SharedPreferences.getInstance();
+      final savedThreads = prefs.getStringList('saved_threads') ?? [];
+      final searchHistory = prefs.getStringList('search_history') ?? [];
+
+      // Create the new thread entry
+      final newThreadEntry = json.encode({
+        'query': widget.query,
+        'summary': widget.summary,
+        'path': file.path,
+        'timestamp': DateTime.now().toIso8601String(),
+        'isSaved': true,
+      });
+
+      // Remove any existing entries with the same query from both lists
+      savedThreads.removeWhere((item) {
+        final decoded = json.decode(item);
+        return decoded['query'] == widget.query;
+      });
+      searchHistory.removeWhere((item) {
+        final decoded = json.decode(item);
+        return decoded['query'] == widget.query;
+      });
+
+      // Add the new thread entry to the saved threads list
+      savedThreads.insert(0, newThreadEntry);
+
+      // Save the updated lists
+      await prefs.setStringList('saved_threads', savedThreads);
+      await prefs.setStringList('search_history', searchHistory);
+
+      debugPrint('Updated saved_threads in SharedPreferences: $savedThreads');
+      debugPrint('Updated search_history in SharedPreferences: $searchHistory');
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Search result copied to clipboard')),
+          SnackBar(content: Text('Thread saved successfully')),
         );
       }
-    });
+    } catch (e) {
+      debugPrint('Error saving thread: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to save thread')),
+        );
+      }
+    }
   }
 
   void _addInitialSection() {
@@ -249,6 +316,24 @@ class ThreadScreenState extends State<ThreadScreen>
       debugPrint('Error performing search: $e');
       setState(() => _isLoading = false);
     }
+  }
+
+  void _loadSavedSections() {
+    _threadSections = widget.savedSections!.map((section) {
+      return ThreadSection(
+        query: section['query'] as String,
+        summary: section['summary'] as String?,
+        searchResults: (section['searchResults'] as List<dynamic>?)
+            ?.map((item) => item as Map<String, dynamic>)
+            .toList(),
+        relatedQuestions: (section['relatedQuestions'] as List<dynamic>?)
+            ?.map((item) => item as String)
+            .toList(),
+        images: (section['images'] as List<dynamic>?)
+            ?.map((item) => Map<String, String?>.from(item))
+            .toList(),
+      );
+    }).toList();
   }
 
   @override
@@ -291,8 +376,8 @@ class ThreadScreenState extends State<ThreadScreen>
               elevation: 0,
               actions: [
                 IconButton(
-                  icon: Icon(Iconsax.export),
-                  onPressed: _shareSearchResult,
+                  icon: Icon(Iconsax.document_download),
+                  onPressed: _downloadThread,
                 ),
               ],
             ),

--- a/lib/screens/thread/thread_screen_state.dart
+++ b/lib/screens/thread/thread_screen_state.dart
@@ -18,6 +18,22 @@ import '../../utils/constants.dart';
 import 'dart:io';
 import 'package:path_provider/path_provider.dart';
 
+class ThreadSection {
+  final String query;
+  String? summary;
+  List<Map<String, dynamic>>? searchResults;
+  List<String>? relatedQuestions;
+  List<Map<String, String?>>? images;
+
+  ThreadSection({
+    required this.query,
+    this.summary,
+    this.searchResults,
+    this.relatedQuestions,
+    this.images,
+  });
+}
+
 class ThreadScreenState extends State<ThreadScreen>
     with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
@@ -213,6 +229,11 @@ class ThreadScreenState extends State<ThreadScreen>
         'query': widget.query,
         'summary': widget.summary,
         'searchResults': widget.searchResults,
+        'images': _threadSections
+            .expand((section) => section.images ?? [])
+            .take(3)
+            .map((img) => Map<String, String?>.from(img))
+            .toList(),
         'sections': _threadSections
             .map((section) => {
                   'query': section.query,
@@ -243,6 +264,7 @@ class ThreadScreenState extends State<ThreadScreen>
         'path': file.path,
         'timestamp': DateTime.now().toIso8601String(),
         'isSaved': true,
+        'images': threadData['images'],
       });
 
       // Remove any existing entries with the same query from both lists
@@ -441,22 +463,6 @@ class ThreadScreenState extends State<ThreadScreen>
       },
     );
   }
-}
-
-class ThreadSection {
-  final String query;
-  String? summary;
-  List<Map<String, dynamic>>? searchResults;
-  List<String>? relatedQuestions;
-  List<Map<String, String?>>? images;
-
-  ThreadSection({
-    required this.query,
-    this.summary,
-    this.searchResults,
-    this.relatedQuestions,
-    this.images,
-  });
 }
 
 class ThreadSectionWidget extends StatelessWidget {

--- a/lib/widgets/library/history_list.dart
+++ b/lib/widgets/library/history_list.dart
@@ -3,163 +3,178 @@ import 'package:iconsax/iconsax.dart';
 import '../../screens/thread/thread_loading_screen.dart';
 import '../../custom_page_route.dart';
 import '../../utils/date_formatter.dart';
+import 'offline_label.dart';
 
-class HistoryList extends StatelessWidget {
+class HistoryList extends StatefulWidget {
   final List<Map<String, dynamic>> searchHistory;
   final Function(int) onDeleteItem;
   final VoidCallback onClearAll;
-  final Function(String) onItemTap;
+  final Function(Map<String, dynamic>) onItemTap;
 
   const HistoryList({
-    super.key,
+    Key? key,
     required this.searchHistory,
     required this.onDeleteItem,
     required this.onClearAll,
     required this.onItemTap,
-  });
+  }) : super(key: key);
+
+  @override
+  _HistoryListState createState() => _HistoryListState();
+}
+
+class _HistoryListState extends State<HistoryList> {
+  late List<Map<String, dynamic>> _searchHistory;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchHistory = List.from(widget.searchHistory);
+  }
+
+  @override
+  void didUpdateWidget(HistoryList oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.searchHistory != oldWidget.searchHistory) {
+      setState(() {
+        _searchHistory = List.from(widget.searchHistory);
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      itemCount: searchHistory.length + 1,
-      separatorBuilder: (context, index) {
-        if (index == 0) return SizedBox.shrink();
-        return Divider(
-          color: Theme.of(context).brightness == Brightness.dark
-              ? Colors.grey[800]
-              : Colors.grey[200],
-          height: 1,
-          thickness: 0.5,
-        );
-      },
-      itemBuilder: (context, index) {
-        if (index == 0) {
-          return _buildClearAllButton(context);
-        }
-        final item = searchHistory[index - 1];
-        return _buildHistoryItem(context, item, index - 1);
-      },
+    return Column(
+      children: [
+        _buildClearAllButton(context),
+        Expanded(
+          child: ListView.builder(
+            itemCount: _searchHistory.length,
+            itemBuilder: (context, index) {
+              return Dismissible(
+                key: ValueKey(_searchHistory[index]['timestamp']),
+                background: Container(
+                  color: Colors.red,
+                  alignment: Alignment.centerRight,
+                  padding: const EdgeInsets.only(right: 20.0),
+                  child: const Icon(Icons.delete, color: Colors.white),
+                ),
+                direction: DismissDirection.endToStart,
+                onDismissed: (direction) {
+                  setState(() {
+                    _searchHistory.removeAt(index);
+                  });
+                  widget.onDeleteItem(index);
+                },
+                confirmDismiss: (DismissDirection direction) async {
+                  return await showDialog(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: const Text("Confirm"),
+                        content: const Text(
+                            "Are you sure you want to delete this item?"),
+                        actions: <Widget>[
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(false),
+                            child: const Text("CANCEL"),
+                          ),
+                          TextButton(
+                            onPressed: () => Navigator.of(context).pop(true),
+                            child: const Text("DELETE"),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                },
+                child: _buildHistoryItem(context, _searchHistory[index], index),
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 
   Widget _buildClearAllButton(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(16.0),
-      child: ElevatedButton(
-        onPressed: onClearAll,
-        style: ElevatedButton.styleFrom(
-          backgroundColor: Colors.grey[800],
-          foregroundColor: Colors.white,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+      child: SizedBox(
+        width: double.infinity,
+        child: ElevatedButton(
+          onPressed: widget.onClearAll,
+          style: ElevatedButton.styleFrom(
+            backgroundColor: Colors.grey[800],
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+            padding: EdgeInsets.symmetric(vertical: 12),
           ),
+          child: Text('Clear All History'),
         ),
-        child: Text('Clear All History'),
       ),
     );
   }
 
   Widget _buildHistoryItem(
       BuildContext context, Map<String, dynamic> item, int index) {
-    return Dismissible(
-      key: Key(item['timestamp']),
-      background: Container(
-        color: Colors.red,
-        alignment: Alignment.centerRight,
-        padding: EdgeInsets.only(right: 16),
-        child: Icon(Iconsax.trash, color: Colors.white),
-      ),
-      direction: DismissDirection.endToStart,
-      onDismissed: (direction) async {
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (context) => AlertDialog(
-            title: Text('Delete History Item'),
-            content: Text('Are you sure you want to delete this history item?'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(false),
-                child: Text('Cancel'),
+    return GestureDetector(
+      onTap: () => widget.onItemTap(item),
+      child: Card(
+        margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      item['query'] ?? 'No query',
+                      style: TextStyle(
+                        color: Theme.of(context).brightness == Brightness.dark
+                            ? Colors.white
+                            : Colors.black,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  if (item['isSaved'] == true) const OfflineLabel(),
+                ],
               ),
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(true),
-                child: Text('Delete'),
+              const SizedBox(height: 8),
+              Text(
+                _truncateSummary(item['summary'] ?? 'No summary available'),
+                style: TextStyle(
+                  color: Theme.of(context).brightness == Brightness.dark
+                      ? Colors.white70
+                      : Colors.black87,
+                  fontSize: 14,
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    formatTimestamp(item['timestamp'] ?? ''),
+                    style: const TextStyle(
+                      color: Colors.grey,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
               ),
             ],
-          ),
-        );
-
-        if (confirmed == true) {
-          onDeleteItem(index);
-        }
-      },
-      child: GestureDetector(
-        onTap: () {
-          Navigator.of(context).push(
-            CustomPageRoute(
-              child: ThreadLoadingScreen(query: item['query']),
-            ),
-          );
-          onItemTap(item['query']);
-        },
-        child: Card(
-          color: Theme.of(context).brightness == Brightness.dark
-              ? Colors.grey[900]
-              : Colors.grey[100], // Make the container transparent
-          margin: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  item['query'],
-                  style: TextStyle(
-                    color: Theme.of(context).brightness == Brightness.dark
-                        ? Colors.white
-                        : Colors.black,
-                    fontWeight: FontWeight.bold,
-                    fontSize: 16,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                SizedBox(height: 8),
-                Text(
-                  item['summary'] != null
-                      ? _truncateSummary(item['summary'])
-                      : 'No summary available',
-                  style: TextStyle(
-                    color: Theme.of(context).brightness == Brightness.dark
-                        ? Colors.white70
-                        : Colors.black87,
-                    fontSize: 14,
-                  ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                SizedBox(height: 8),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(
-                      formatTimestamp(item['timestamp']),
-                      style: TextStyle(
-                        color: Colors.white70,
-                        fontSize: 12,
-                      ),
-                    ),
-                    IconButton(
-                      icon:
-                          Icon(Iconsax.trash, color: Colors.white70, size: 20),
-                      onPressed: () => onDeleteItem(index),
-                    ),
-                  ],
-                ),
-              ],
-            ),
           ),
         ),
       ),

--- a/lib/widgets/library/history_list.dart
+++ b/lib/widgets/library/history_list.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:iconsax/iconsax.dart';
-import '../../screens/thread/thread_loading_screen.dart';
-import '../../custom_page_route.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import '../../utils/date_formatter.dart';
 import 'offline_label.dart';
+import 'package:iconsax/iconsax.dart';
 
-class HistoryList extends StatefulWidget {
+class HistoryList extends StatelessWidget {
   final List<Map<String, dynamic>> searchHistory;
   final Function(int) onDeleteItem;
   final VoidCallback onClearAll;
@@ -20,76 +19,16 @@ class HistoryList extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _HistoryListState createState() => _HistoryListState();
-}
-
-class _HistoryListState extends State<HistoryList> {
-  late List<Map<String, dynamic>> _searchHistory;
-
-  @override
-  void initState() {
-    super.initState();
-    _searchHistory = List.from(widget.searchHistory);
-  }
-
-  @override
-  void didUpdateWidget(HistoryList oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.searchHistory != oldWidget.searchHistory) {
-      setState(() {
-        _searchHistory = List.from(widget.searchHistory);
-      });
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         _buildClearAllButton(context),
         Expanded(
           child: ListView.builder(
-            itemCount: _searchHistory.length,
+            physics: BouncingScrollPhysics(),
+            itemCount: searchHistory.length,
             itemBuilder: (context, index) {
-              return Dismissible(
-                key: ValueKey(_searchHistory[index]['timestamp']),
-                background: Container(
-                  color: Colors.red,
-                  alignment: Alignment.centerRight,
-                  padding: const EdgeInsets.only(right: 20.0),
-                  child: const Icon(Icons.delete, color: Colors.white),
-                ),
-                direction: DismissDirection.endToStart,
-                onDismissed: (direction) {
-                  setState(() {
-                    _searchHistory.removeAt(index);
-                  });
-                  widget.onDeleteItem(index);
-                },
-                confirmDismiss: (DismissDirection direction) async {
-                  return await showDialog(
-                    context: context,
-                    builder: (BuildContext context) {
-                      return AlertDialog(
-                        title: const Text("Confirm"),
-                        content: const Text(
-                            "Are you sure you want to delete this item?"),
-                        actions: <Widget>[
-                          TextButton(
-                            onPressed: () => Navigator.of(context).pop(false),
-                            child: const Text("CANCEL"),
-                          ),
-                          TextButton(
-                            onPressed: () => Navigator.of(context).pop(true),
-                            child: const Text("DELETE"),
-                          ),
-                        ],
-                      );
-                    },
-                  );
-                },
-                child: _buildHistoryItem(context, _searchHistory[index], index),
-              );
+              return _buildHistoryItem(context, searchHistory[index], index);
             },
           ),
         ),
@@ -103,7 +42,7 @@ class _HistoryListState extends State<HistoryList> {
       child: SizedBox(
         width: double.infinity,
         child: ElevatedButton(
-          onPressed: widget.onClearAll,
+          onPressed: onClearAll,
           style: ElevatedButton.styleFrom(
             backgroundColor: Colors.grey[800],
             foregroundColor: Colors.white,
@@ -120,62 +59,140 @@ class _HistoryListState extends State<HistoryList> {
 
   Widget _buildHistoryItem(
       BuildContext context, Map<String, dynamic> item, int index) {
-    return GestureDetector(
-      onTap: () => widget.onItemTap(item),
-      child: Card(
-        margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Expanded(
-                    child: Text(
-                      item['query'] ?? 'No query',
-                      style: TextStyle(
-                        color: Theme.of(context).brightness == Brightness.dark
-                            ? Colors.white
-                            : Colors.black,
-                        fontWeight: FontWeight.bold,
-                        fontSize: 16,
+    List<String> images = [];
+    debugPrint('Processing item: $item'); // Log the entire item
+
+    if (item['images'] != null && item['images'] is List) {
+      debugPrint('Images found: ${item['images']}'); // Log the images list
+      images = (item['images'] as List)
+          .where((img) {
+            bool isValid = img is Map<String, dynamic> && img['url'] != null;
+            debugPrint(
+                'Image $img is valid: $isValid'); // Log each image validity
+            return isValid;
+          })
+          .map((img) => img['url'] as String)
+          .take(3)
+          .toList();
+      debugPrint('Processed images: $images'); // Log the processed images
+    } else {
+      debugPrint('No images found or invalid image data');
+    }
+
+    return Dismissible(
+      key: ValueKey(item['timestamp']),
+      background: Container(
+        color: const Color.fromARGB(132, 244, 67, 54),
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20.0),
+        child: const Icon(Iconsax.trash, color: Colors.white),
+      ),
+      direction: DismissDirection.endToStart,
+      onDismissed: (direction) {
+        onDeleteItem(index);
+      },
+      child: GestureDetector(
+        onTap: () => onItemTap(item),
+        child: Card(
+          margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        item['query'] ?? 'No query',
+                        style: TextStyle(
+                          color: Theme.of(context).brightness == Brightness.dark
+                              ? Colors.white
+                              : Colors.black,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
                     ),
-                  ),
-                  if (item['isSaved'] == true) const OfflineLabel(),
-                ],
-              ),
-              const SizedBox(height: 8),
-              Text(
-                _truncateSummary(item['summary'] ?? 'No summary available'),
-                style: TextStyle(
-                  color: Theme.of(context).brightness == Brightness.dark
-                      ? Colors.white70
-                      : Colors.black87,
-                  fontSize: 14,
+                    if (item['isSaved'] == true) const OfflineLabel(),
+                  ],
                 ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: 8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    formatTimestamp(item['timestamp'] ?? ''),
-                    style: const TextStyle(
-                      color: Colors.grey,
-                      fontSize: 12,
-                    ),
+                const SizedBox(height: 8),
+                Text(
+                  _truncateSummary(item['summary'] ?? 'No summary available'),
+                  style: TextStyle(
+                    color: Theme.of(context).brightness == Brightness.dark
+                        ? Colors.white70
+                        : Colors.black87,
+                    fontSize: 14,
                   ),
-                ],
-              ),
-            ],
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 8),
+                if (images.isNotEmpty)
+                  SizedBox(
+                    height: 60,
+                    child: ListView.builder(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: images.length,
+                      itemBuilder: (context, index) {
+                        debugPrint(
+                            'Building image thumbnail for ${images[index]}');
+                        return _buildImageThumbnail(images[index]);
+                      },
+                    ),
+                  )
+                else
+                  SizedBox.shrink(
+                    child: Text('No images to display'),
+                  ),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      formatTimestamp(item['timestamp'] ?? ''),
+                      style: const TextStyle(
+                        color: Colors.grey,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildImageThumbnail(String imageUrl) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8.0),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(8),
+        child: CachedNetworkImage(
+          imageUrl: imageUrl,
+          width: 60,
+          height: 60,
+          fit: BoxFit.cover,
+          placeholder: (context, url) {
+            debugPrint('Loading image: $url');
+            return Container(
+              width: 60,
+              height: 60,
+              color: Colors.grey[300],
+            );
+          },
+          errorWidget: (context, url, error) {
+            debugPrint('Error loading image: $url, Error: $error');
+            return const SizedBox.shrink();
+          },
         ),
       ),
     );

--- a/lib/widgets/library/offline_label.dart
+++ b/lib/widgets/library/offline_label.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import '';
+
+class OfflineLabel extends StatelessWidget {
+  const OfflineLabel({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: Color.fromRGBO(28, 36, 31, 1),
+        border: Border.all(color: Color.fromRGBO(70, 92, 30, 1)),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        'Offline',
+        style: TextStyle(
+          color: Color.fromRGBO(168, 221, 32, 1),
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/library/offline_label.dart
+++ b/lib/widgets/library/offline_label.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
-import '';
 
 class OfflineLabel extends StatelessWidget {
-  const OfflineLabel({Key? key}) : super(key: key);
+  const OfflineLabel({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/thread/sources_section.dart
+++ b/lib/widgets/thread/sources_section.dart
@@ -10,10 +10,10 @@ class SourcesSection extends StatefulWidget {
   const SourcesSection({super.key, required this.searchResults});
 
   @override
-  _SourcesSectionState createState() => _SourcesSectionState();
+  State<SourcesSection> createState() => SourcesSectionState();
 }
 
-class _SourcesSectionState extends State<SourcesSection> {
+class SourcesSectionState extends State<SourcesSection> {
   bool _isExpanded = false;
 
   @override
@@ -213,7 +213,7 @@ class _SourcesSectionState extends State<SourcesSection> {
         ),
       );
     }
-    return Container(
+    return SizedBox(
       width: 40,
       height: 24,
       child: Stack(children: favicons),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
 
+  
   cupertino_icons: ^1.0.2
   flutter_slidable: ^3.1.1
   http: ^1.2.2


### PR DESCRIPTION
This pull request includes several changes to the `build_and_release.yml` workflow file and various Dart files to enhance the library and thread screen functionalities. The most important changes include updating the conditions for artifact uploads, improving the handling of search history and saved threads, and adding new methods for managing and displaying threads.

### Workflow Changes:
* [`.github/workflows/build_and_release.yml`](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L97-R113): Changed the condition for uploading APKs from the `main` branch to the `dev` branch.
* [`.github/workflows/build_and_release.yml`](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L140-R140): Updated the asset names to use a capitalized "Freelexity" instead of "freelexity". [[1]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L140-R140) [[2]](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L162-R162)
* [`.github/workflows/build_and_release.yml`](diffhunk://#diff-1fc0f49e0ca10edf5167c1d078ad74a990e176ff6d704e53d967a6b8a0076437L172-L195): Removed redundant steps for uploading dev APKs as artifacts.

### Library Screen Enhancements:
* [`lib/screens/library/library_screen_state.dart`](diffhunk://#diff-d44d7548bcdb1a19c79114669016f53758738d5a09701e5daf33c4710533db27R4-L17): Added functionality to load, save, and manage search history and saved threads. Introduced methods `_onDeleteItem`, `_onClearAll`, `_saveSearchHistory`, and `_handleItemTap`. [[1]](diffhunk://#diff-d44d7548bcdb1a19c79114669016f53758738d5a09701e5daf33c4710533db27R4-L17) [[2]](diffhunk://#diff-d44d7548bcdb1a19c79114669016f53758738d5a09701e5daf33c4710533db27L32-R78) [[3]](diffhunk://#diff-d44d7548bcdb1a19c79114669016f53758738d5a09701e5daf33c4710533db27R87-R128) [[4]](diffhunk://#diff-d44d7548bcdb1a19c79114669016f53758738d5a09701e5daf33c4710533db27L67-R191)

### Thread Screen Enhancements:
* [`lib/screens/thread/thread_loading_screen.dart`](diffhunk://#diff-d4e131c319796239df77d7172c3523e23b1fb7b4825236801d01b60e83544caaR2-R21): Enhanced the loading screen to handle saved thread data and paths, with methods `_loadThreadOrSearch` and `_loadSavedThread`. [[1]](diffhunk://#diff-d4e131c319796239df77d7172c3523e23b1fb7b4825236801d01b60e83544caaR2-R21) [[2]](diffhunk://#diff-d4e131c319796239df77d7172c3523e23b1fb7b4825236801d01b60e83544caaL24-L50) [[3]](diffhunk://#diff-d4e131c319796239df77d7172c3523e23b1fb7b4825236801d01b60e83544caaL60-R102)
* [`lib/screens/thread/thread_screen.dart`](diffhunk://#diff-4680eceddc30b8ae9d09273bdcb2914da9dfd2b5ae255ca088bd409a5e6cf4bfR8-R15): Added support for displaying saved sections in the `ThreadScreen` widget.
* [`lib/screens/thread/thread_screen_state.dart`](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8R18-R42): Implemented `_downloadThread` method to save thread data to a file and update SharedPreferences. [[1]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8R18-R42) [[2]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L36-R60) [[3]](diffhunk://#diff-9caf607a6ac5d005e478b8040f39fe23238c5195fba6efa82f0cf3066770baf8L204-R302)